### PR TITLE
Add lazy loading to `add_config`

### DIFF
--- a/_tests/other_module.py
+++ b/_tests/other_module.py
@@ -3,6 +3,7 @@
 from hparams import configurable
 from hparams import HParam
 
+
 @configurable
 def configured(arg=HParam()):
     return arg

--- a/_tests/other_module.py
+++ b/_tests/other_module.py
@@ -1,0 +1,8 @@
+""" A module outside of `tests` used for testing `hparams`. """
+
+from hparams import configurable
+from hparams import HParam
+
+@configurable
+def configured(arg=HParam()):
+    return arg

--- a/hparams/__init__.py
+++ b/hparams/__init__.py
@@ -6,9 +6,10 @@ from hparams.hparams import HParam
 from hparams.hparams import HParams
 from hparams.hparams import log_config
 from hparams.hparams import parse_hparam_args
+from hparams.hparams import set_lazy_resolution
 
 __all__ = [
     'HParams', 'HParam', 'add_config', 'clear_config', 'log_config', 'configurable', 'get_config',
-    'parse_hparam_args'
+    'parse_hparam_args', 'set_lazy_resolution'
 ]
 __version__ = '0.3.0'

--- a/hparams/hparams.py
+++ b/hparams/hparams.py
@@ -158,6 +158,9 @@ def _function_has_keyword_parameters(func, kwargs):
                             (_get_function_signature(func), kwarg, type_hints[kwarg]))
 
 
+_skip_resolution = []
+
+
 def _resolve_configuration_helper(dict_, keys):
     """ Recursive helper of `_resolve_configuration`.
 
@@ -193,10 +196,19 @@ def _resolve_configuration_helper(dict_, keys):
         raise TypeError('Failed to find `HParams` object along path `%s`.' % '.'.join(keys))
 
     trace = []
-    for i in reversed(range(1, len(keys))):
+    for i in range(1, len(keys)):
         try:
             module_path = '.'.join(keys[:i])
-            attribute = import_module(module_path)
+
+            if _is_lazy_resolution:
+                # NOTE: If the module is not already loaded, then skip this resolution for now.
+                attribute = sys.modules.get(module_path, None)
+                if attribute is None:
+                    _skip_resolution.append((dict_, keys[:]))
+                    return {}
+            else:
+                attribute = import_module(module_path)
+
             for j, key in enumerate(keys[i:]):
                 # NOTE: `__qualname__` uses `<locals>` and `<lambdas>` for function naming.
                 # Learn more: https://www.python.org/dev/peps/pep-3155/
@@ -206,6 +218,8 @@ def _resolve_configuration_helper(dict_, keys):
                     signature = (_get_function_signature(attribute) + '.' + '.'.join(keys[i:][j:]))
                     return {signature: dict_}
                 else:
+                    # NOTE: This will fail if `key` is a module that has not yet been imported
+                    # and `attribute` is a package.
                     attribute = getattr(attribute, key)
             if hasattr(attribute, '_configurable'):
                 # Check all keyword arguments (`dict_`) are defined in function.
@@ -216,6 +230,8 @@ def _resolve_configuration_helper(dict_, keys):
                 return {_get_function_signature(attribute.__wrapped__): dict_}
             else:
                 trace.append('`%s` is not decorated with `configurable`.' % '.'.join(keys))
+        # TODO: Instead of the generic `ImportError` consider a the more specific
+        # `ModuleNotFoundError` introduced in Python 3.6
         except ImportError:
             trace.append('ImportError: Failed to run `import %s`.' % module_path)
         except AttributeError:
@@ -248,6 +264,33 @@ def _resolve_configuration(dict_):
         dict: Each key is a function signature and each value is an `HParams` object.
     """
     return _resolve_configuration_helper(dict_, [])
+
+
+def _resolve_skipped():
+    """ Invoke resolution for skipped configuration paths.
+    """
+    # NOTE: `_resolve_configuration_helper` adds more items to `_skip_resolution`, this ensures
+    # that those items are ignored.
+    global _skip_resolution
+    copy_skip_resolution = _skip_resolution.copy()
+    _skip_resolution = []
+
+    for args in copy_skip_resolution:
+        resolved = _resolve_configuration_helper(*args)
+        _add_resolved_config(resolved)
+
+
+def _add_resolved_config(resolved):
+    """ Add to `configuration` a resolved configuration from `_resolve_configuration`.
+
+    Args:
+        resolved (dict): Each key is a function signature and each value is an `HParams` object.
+    """
+    for key in resolved:
+        if key in _configuration:
+            _configuration[key].update(resolved[key])
+        else:
+            _configuration[key] = resolved[key]
 
 
 def _parse_configuration_helper(dict_, parsed_dict):
@@ -355,18 +398,11 @@ def add_config(config):
         [[1,
           2]]
     """
-    global _configuration
-
     if len(config) == 0:
         return
-
     parsed = _parse_configuration(config)
     resolved = _resolve_configuration(parsed)
-    for key in resolved:
-        if key in _configuration:
-            _configuration[key].update(resolved[key])
-        else:
-            _configuration[key] = resolved[key]
+    _add_resolved_config(resolved)
 
 
 def log_config():
@@ -383,6 +419,10 @@ def get_config():
     Returns:
         (dict): The current configuration.
     """
+    if _is_lazy_resolution and len(_skip_resolution) > 0:
+        logger.warning(
+            'There are unresolved configurations because lazy resolution was set to `True`; '
+            'therefore, this will only return a partial config.')
     return _configuration
 
 
@@ -394,6 +434,23 @@ def clear_config():
     """
     global _configuration
     _configuration = {}
+
+
+_is_lazy_resolution = False
+
+
+def set_lazy_resolution(bool_):
+    """ Set `HParams` to resolve configurations during when a configured function
+    is executed instead of when `add_config` is executed.
+
+    This lazy resolution ensures that no modules are imported that are not.
+
+    Args:
+        bool_ (bool): If `True` the configurations are resolved and checked lazily.
+    """
+    global _is_lazy_resolution
+    _is_lazy_resolution = bool_
+    _resolve_skipped()
 
 
 def _merge_args(parameters, args, kwargs, config_kwargs, default_kwargs, print_name):
@@ -500,6 +557,8 @@ def configurable(function=None):
     @wraps(function)
     def decorator(*args, **kwargs):
         global _configuration
+
+        _resolve_skipped()
 
         # Get the function configuration
         config = _get_configuration()

--- a/hparams/hparams.py
+++ b/hparams/hparams.py
@@ -39,7 +39,7 @@ class HParam():
     """
 
     def __init__(self, type_=Any):
-        stack = inspect.stack()[1] # Get the caller line number
+        stack = inspect.stack()[1]  # Get the caller line number
         self.type = type_
         self.error_message = 'The parameter set to `HParam` at %s:%s must be configured.' % (
             stack.filename, stack.lineno)

--- a/hparams/hparams.py
+++ b/hparams/hparams.py
@@ -39,11 +39,10 @@ class HParam():
     """
 
     def __init__(self, type_=Any):
-        lineno = inspect.stack()[1].lineno  # Ge the caller line number
-        filename = inspect.stack()[1].filename
+        stack = inspect.stack()[1] # Get the caller line number
         self.type = type_
         self.error_message = 'The parameter set to `HParam` at %s:%s must be configured.' % (
-            filename, lineno)
+            stack.filename, stack.lineno)
         # Learn more about special methods:
         # https://stackoverflow.com/questions/21887091/cant-dynamically-bind-repr-str-to-a-class-created-with-type
         # https://stackoverflow.com/questions/1418825/where-is-the-python-documentation-for-the-special-methods-init-new

--- a/hparams/hparams.py
+++ b/hparams/hparams.py
@@ -39,7 +39,7 @@ class HParam():
     """
 
     def __init__(self, type_=Any):
-        stack = inspect.stack()[1]  # Get the caller line number
+        stack = inspect.stack(0)[1]  # Get the caller line number
         self.type = type_
         self.error_message = 'The parameter set to `HParam` at %s:%s must be configured.' % (
             stack.filename, stack.lineno)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+from hparams.hparams import clear_config
+from hparams.hparams import set_lazy_resolution
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def run_before_test():
+    # Reset the global state before every test
+    clear_config()
+    set_lazy_resolution(False)
+    yield


### PR DESCRIPTION
At the moment, `add_config` imports every module that is referenced in the configuration in order to check the function signature and path. With this PR, we add an option to lazily import modules only if they are already in `sys.modules`.

This optionality should increase initialization speed but it potentially leaves room for some configurations to not be checked because they are never run during runtime. 

Finally:
- Added a couple of comments 
- Added a `conftest` file so that `pytest` rests the global state before each test.
- Remove redundant call to `inspect.stack`
- Improve `HParam` initialization performance like so: https://stackoverflow.com/questions/17407119/python-inspect-stack-is-slow