### PR TITLE
Further improve `HParam` performance by 18x

### DIFF
--- a/hparams/hparams.py
+++ b/hparams/hparams.py
@@ -11,6 +11,7 @@ import itertools
 import logging
 import pprint
 import sys
+import traceback
 import warnings
 
 from typeguard import check_type
@@ -39,7 +40,7 @@ class HParam():
     """
 
     def __init__(self, type_=Any):
-        stack = inspect.stack(0)[1]  # Get the caller line number
+        stack = traceback.extract_stack(limit=2)[-2]  # Get the caller line number
         self.type = type_
         self.error_message = 'The parameter set to `HParam` at %s:%s must be configured.' % (
             stack.filename, stack.lineno)


### PR DESCRIPTION
This uses `traceback.extract_stack(limit=2)[-2]` instead of `inspect.stack(0)[1]` because it's faster. This is the benchmark:
```python
import inspect
import sys
import time
import timeit
import traceback


def deeper(func, depth):
    if depth > 0:
        return deeper(func, depth - 1)
    else:
        return func()


def no_stack():
    pass


def bench_stack():
    return inspect.stack()[1].filename, inspect.stack()[1].lineno


def bench_stack_limit():
    return inspect.stack(0)[1].filename, inspect.stack(0)[1].lineno


def bench_trace():
    return traceback.extract_stack()[-2].filename, traceback.extract_stack()[-2].lineno


def bench_trace_limit():
    return (traceback.extract_stack(limit=2)[-2].filename,
            traceback.extract_stack(limit=2)[-2].lineno)


assert deeper(bench_trace_limit, depth=5) == deeper(bench_stack, depth=5)
assert deeper(bench_trace, depth=5) == deeper(bench_stack, depth=5)
assert deeper(bench_stack_limit, depth=5) == deeper(bench_stack, depth=5)

samples = 10000
print('baseline:', timeit.timeit(lambda: deeper(no_stack, depth=5), number=samples))
print('bench_stack:', timeit.timeit(lambda: deeper(bench_stack, depth=5), number=samples))
print('bench_stack_limit:',
      timeit.timeit(lambda: deeper(bench_stack_limit, depth=5), number=samples))
print('bench_trace:', timeit.timeit(lambda: deeper(bench_trace, depth=5), number=samples))
print('bench_trace_limit:',
      timeit.timeit(lambda: deeper(bench_trace_limit, depth=5), number=samples))
```

The benchmark was inspired by: https://gist.github.com/JettJones/c236494013f22723c1822126df944b12

These were the results:
```
baseline: 0.008920529999999996
bench_stack: 17.366878454000002
bench_stack_limit: 4.497257854999997
bench_trace: 0.9375153429999976
bench_trace_limit: 0.2445523019999989
```